### PR TITLE
Add ability to use custom text on StartTimeList/Item

### DIFF
--- a/docs/src/reactComponentLib/components/ScheduleMeeting/ScheduleMeeting.d.ts
+++ b/docs/src/reactComponentLib/components/ScheduleMeeting/ScheduleMeeting.d.ts
@@ -12,6 +12,7 @@ export type ModifiedTimeslot = AvailableTimeslot & {
 export type StartTimeEvent = {
     availableTimeslot: AvailableTimeslot;
     startTime: Date;
+    endTime: Date;
 };
 export type StartTimeEventEmit = StartTimeEvent & {
     splitTimeslot?: [SplitTimeslot, SplitTimeslot];
@@ -31,6 +32,7 @@ type Props = {
     format_selectedDateDayTitleFormatString?: string;
     format_selectedDateMonthTitleFormatString?: string;
     format_startTimeFormatString?: string;
+    format_startTimeTextString?: string;
     lang_cancelButtonText?: string;
     lang_confirmButtonText?: string;
     lang_emptyListText?: string;

--- a/docs/src/reactComponentLib/components/ScheduleMeeting/StartTimeList.d.ts
+++ b/docs/src/reactComponentLib/components/ScheduleMeeting/StartTimeList.d.ts
@@ -9,6 +9,7 @@ type Props = {
     onStartTimeSelect: (startTimeEvent: StartTimeEvent) => void;
     emptyListContentEl?: React.ElementType;
     format_startTimeFormatString: string;
+    format_startTimeTextString: string;
     lang_emptyListText: string;
     lang_confirmButtonText: string;
     lang_cancelButtonText: string;

--- a/docs/src/reactComponentLib/components/ScheduleMeeting/StartTimeListItem.d.ts
+++ b/docs/src/reactComponentLib/components/ScheduleMeeting/StartTimeListItem.d.ts
@@ -7,6 +7,7 @@ type Props = {
     confirmState?: boolean;
     onCancelClicked: () => void;
     format_startTimeFormatString: string;
+    format_startTimeTextString: string;
     lang_confirmButtonText: string;
     lang_cancelButtonText: string;
     lang_selectedButtonText: string;

--- a/src/components/ScheduleMeeting/ScheduleMeeting.tsx
+++ b/src/components/ScheduleMeeting/ScheduleMeeting.tsx
@@ -144,6 +144,7 @@ export type ModifiedTimeslot = AvailableTimeslot & {
 export type StartTimeEvent = {
   availableTimeslot: AvailableTimeslot;
   startTime: Date;
+  endTime: Date;
 };
 
 export type StartTimeEventEmit = StartTimeEvent & {
@@ -165,6 +166,7 @@ type Props = {
   format_selectedDateDayTitleFormatString?: string;
   format_selectedDateMonthTitleFormatString?: string;
   format_startTimeFormatString?: string;
+  format_startTimeTextString?: string;
   lang_cancelButtonText?: string;
   lang_confirmButtonText?: string;
   lang_emptyListText?: string;
@@ -196,6 +198,7 @@ export const ScheduleMeeting: React.FC<Props> = ({
   format_selectedDateDayTitleFormatString = 'cccc, LLLL do',
   format_selectedDateMonthTitleFormatString = 'LLLL yyyy',
   format_startTimeFormatString = 'h:mm a',
+  format_startTimeTextString = '',
   lang_cancelButtonText = 'Cancel',
   lang_confirmButtonText = 'Confirm',
   lang_emptyListText = 'No times available',
@@ -314,12 +317,15 @@ export const ScheduleMeeting: React.FC<Props> = ({
         Math.floor(timeslotDuration / (eventDurationInMinutes + eventStartTimeSpreadInMinutes)) - 1;
 
       while (startTimesPossible >= 0) {
+
+        var startDateTime = addMinutes(
+          new Date(availableTimeslot.startTime),
+          startTimesPossible * (eventDurationInMinutes + eventStartTimeSpreadInMinutes),
+        )
         const newStartTimeEvent: StartTimeEvent = {
           availableTimeslot,
-          startTime: addMinutes(
-            new Date(availableTimeslot.startTime),
-            startTimesPossible * (eventDurationInMinutes + eventStartTimeSpreadInMinutes),
-          ),
+          startTime: startDateTime,
+          endTime: addMinutes(startDateTime, eventDurationInMinutes)
         };
         startTimeEvents.push(newStartTimeEvent);
         startTimesPossible--;
@@ -461,6 +467,7 @@ export const ScheduleMeeting: React.FC<Props> = ({
               onStartTimeSelect={_onStartTimeSelect}
               startTimeListItems={selectedDayStartTimeEventsList}
               format_startTimeFormatString={format_startTimeFormatString}
+              format_startTimeTextString={format_startTimeTextString}
               startTimeListStyle={startTimeListStyle}
               setSelectedStartTime={setSelectedStartTime}
             />

--- a/src/components/ScheduleMeeting/StartTimeList.tsx
+++ b/src/components/ScheduleMeeting/StartTimeList.tsx
@@ -17,6 +17,7 @@ type Props = {
   onStartTimeSelect: (startTimeEvent: StartTimeEvent) => void;
   emptyListContentEl?: React.ElementType;
   format_startTimeFormatString: string;
+  format_startTimeTextString: string;
   lang_emptyListText: string;
   lang_confirmButtonText: string;
   lang_cancelButtonText: string;
@@ -138,6 +139,7 @@ const StartTimeList: React.FC<Props> = ({
   emptyListContentEl,
   lang_emptyListText,
   format_startTimeFormatString,
+  format_startTimeTextString,
   lang_confirmButtonText,
   lang_cancelButtonText,
   lang_goToNextAvailableDayText,
@@ -198,6 +200,10 @@ const StartTimeList: React.FC<Props> = ({
     }
   };
 
+  const parseString = (str: string, startTime: string, endTime: string) => {
+    return str.replace(/\$startTime/g, startTime).replace(/\$endTime/g, endTime);
+  }
+
   return (
     <>
       {startTimeListItems.length === 0 ? (
@@ -215,6 +221,7 @@ const StartTimeList: React.FC<Props> = ({
                   lang_confirmButtonText={lang_confirmButtonText}
                   lang_cancelButtonText={lang_cancelButtonText}
                   format_startTimeFormatString={format_startTimeFormatString}
+                  format_startTimeTextString={format_startTimeTextString}
                   onCancelClicked={() => handleCancelClicked(startTimeEvent)}
                   selected={Boolean(selectedStartTime && selectedStartTime === startTimeEvent.startTime.getTime())}
                   confirmState={i === selectedItemIndex}
@@ -239,7 +246,7 @@ const StartTimeList: React.FC<Props> = ({
               }
               onClick={() => onStartTimeSelect(startTimeEvent)}
             >
-              {format(startTimeEvent.startTime, format_startTimeFormatString, { locale })}
+              {format_startTimeTextString !== "" ? parseString(format_startTimeTextString,format(startTimeEvent.startTime, format_startTimeFormatString, { locale }), format(startTimeEvent.endTime, format_startTimeFormatString, { locale }) ) : format(startTimeEvent.startTime, format_startTimeFormatString, { locale })}
             </StartTimeGridItemButton>
           ))}
         </GridContainer>

--- a/src/components/ScheduleMeeting/StartTimeListItem.tsx
+++ b/src/components/ScheduleMeeting/StartTimeListItem.tsx
@@ -11,6 +11,7 @@ type Props = {
   confirmState?: boolean;
   onCancelClicked: () => void;
   format_startTimeFormatString: string;
+  format_startTimeTextString: string;
   lang_confirmButtonText: string;
   lang_cancelButtonText: string;
   lang_selectedButtonText: string;
@@ -49,11 +50,16 @@ const StartTimeListItem: React.FC<Props> = ({
   selected,
   onCancelClicked,
   format_startTimeFormatString,
+  format_startTimeTextString,
   lang_confirmButtonText,
   lang_cancelButtonText,
   lang_selectedButtonText,
   locale,
 }) => {
+  const parseString = (str: string, startTime: string, endTime: string) => {
+    return str.replace(/\$startTime/g, startTime).replace(/\$endTime/g, endTime);
+  }
+
   return (
     <Container className="rsm-start-time-item">
       <ThemedButton
@@ -64,7 +70,7 @@ const StartTimeListItem: React.FC<Props> = ({
       >
         {confirmState && !selected && `${lang_confirmButtonText} `}
         {selected && `${lang_selectedButtonText} `}
-        {format(startTimeEvent.startTime, format_startTimeFormatString, { locale })}
+        {format_startTimeTextString !== "" ? parseString(format_startTimeTextString, format(startTimeEvent.startTime, format_startTimeFormatString, { locale }), format(startTimeEvent.endTime, format_startTimeFormatString, { locale }) ) : format(startTimeEvent.startTime, format_startTimeFormatString, { locale })}
       </ThemedButton>
       {(confirmState || selected) && (
         <CancelButton type="button" className="rsm-cancel-button" onClick={onCancelClicked}>


### PR DESCRIPTION
#66 Using variables $startTime and $endTime to parse possible values that can be used in the text. Will also use a custom date format based on what is submitted in the format_startTimeFormatString prop

![image](https://user-images.githubusercontent.com/30943151/218297275-6997bbf6-e673-4fce-805a-1ab960bedb59.png)

![image](https://user-images.githubusercontent.com/30943151/218297289-c4ec5269-b6b5-43f0-bb64-95b8f1785dc3.png)
